### PR TITLE
feat: Allow providing zipfile by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ use.
     steps:
       - uses: esp-cpp/esp-packaged-programmer-action@v1.0.1
         with:
-          zipfile-id: ${{ needs.build.outputs.zipfile-id }}
+          zipfile-name: 'your-build-artifacts'
           programmer-name: 'your_programmer_name'
 ```
+
+> NOTE: you can use either `zipfile-name` or `zipfile-id` as input to this
+> script. If you are using MATRIX strategy (for which you may struggle to get
+> the zipfile id output for each step), you may want to use the `zipfile-name`
+> instead.
 
 See the example in [Using this action](#using-this-action) for a more complete
 example showing how to build your code and zip it for use by this action.
@@ -78,6 +83,10 @@ Below is an example workflow file that:
 3. Runs this action (`esp-cpp/esp-packaged-programmer-action`) to build those
    binaries into executable flashing programs for `windows`, `macos`, and
    `linux`.
+
+In the example below, we are using the `zipfile-id` input and hard-linking that
+to the `build` job output. You could instead use the `zipfile-name` input and
+provide it the name of the artifact (`firmware`) in this case.
 
 ```yaml
 on: 

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,13 @@ name: 'ESP Packaged Programmer'
 description: 'Package esptool and the binaries into an executable'
 inputs:
   zipfile-id:
-    description: 'Artifact ID for the Zipfile to download. Zipfile should contain firmware.bin, bootloader.bin, partition-table.bin, and flasher_args.json. May optionally contain filesystem binaries and associated -flash_args files.'
-    required: true
+    description: 'Artifact ID for the Zipfile to download. Zipfile should contain firmware.bin, bootloader.bin, partition-table.bin, and flasher_args.json. May optionally contain filesystem binaries and associated -flash_args files. NOTE: only one of zipfile-id or zipfile-name should be set.'
+    required: false
+    default: ''
+  zipfile-name:
+    description: 'Name of the zipfile artifact that was packaged and uploaded. Zipfile should contain firmware.bin, bootloader.bin, partition-table.bin, and flasher_args.json. May optionally contain filesystem binaries and associated -flash_args files. NOTE: only one of zipfile-id or zipfile-name should be set.'
+    required: false
+    default: ''
   programmer-name:
     description: 'Base name of the programmer executable. Will have version tag (e.g. v1.0.0 or commit hash if no tags) and OS suffix (e.g. windows, linux, macos) appended.'
     required: false
@@ -15,6 +20,20 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Ensure that one of zipfile-id or zipfile-name is set
+      if: ${{ inputs.zipfile-id == '' && inputs.zipfile-name == '' }}
+      shell: bash
+      run: |
+        echo "::error title=⛔ error hint::Either zipfile-id or zipfile-name must be set"
+        exit 1
+
+    - name: Ensure that only zipfile-id or zipfile-name is set, not both
+      if: ${{ inputs.zipfile-id != '' && inputs.zipfile-name != '' }}
+      shell: bash
+      run: |
+        echo "::error title=⛔ error hint::Only one of zipfile-id or zipfile-name can be set"
+        exit 1
+
     - name: Check Runner OS
       if: ${{ runner.os != 'Linux' && runner.os != 'Windows' && runner.os != 'macOS'}}
       shell: bash
@@ -53,6 +72,7 @@ runs:
       uses: actions/download-artifact@v4
       id: download_zipfile
       with:
+        name: ${{ inputs.zipfile-name }}
         artifact-ids: ${{ inputs.zipfile-id }}
         path: ${{ github.action_path }}/build
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Change `zipfile-id` to not be required and have default value of ''
* Add input `zipfile-name` (also not required) with default value of ''
* Add steps to check that exactly one of zipfile-id and zipfile-name is set

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some cases (such as via matrix strategy) you cannot easily use the zipfile-id as input because getting the output from matrix steps can be tricky. Allowing name to be provided helps in such cases.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It hasn't yet. :sweat_smile:

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
